### PR TITLE
Fix bytestring.js import

### DIFF
--- a/runtime/bytestring_internal.js
+++ b/runtime/bytestring_internal.js
@@ -4,7 +4,7 @@
  * kernel and APIs directly using the binary kernel.
  */
 
-import ByteString from "../runtime/bytestring.js";
+import ByteString from "./bytestring.js";
 
 /**
  * Constructs a ByteString from an Uint8Array. DON'T MODIFY the underlying


### PR DESCRIPTION
I'm using this to generate classes, but at the top of my generated `.ts` file, these imports fail:
```
import Kernel from "https://deno.land/x/protobuf/kernel/kernel.js";
import Int64 from "https://deno.land/x/protobuf/int64.js";
```

Importing from deno.land fails because this import is defined as `../runtime/byestring.js`, but it is hosted on deno.land at `protobuf/bytestring.js`. 


```
Download https://deno.land/x/protobuf/bytestring_internal.js
Download https://deno.land/x/runtime/bytestring.js
Import 'https://deno.land/x/runtime/bytestring.js' failed: 404 Not Found
```

Switching `../runtime/bytestring.js` with `./bytestring.js` means the import is correct in this repository and in the directory structure on deno.land.